### PR TITLE
Extract health-logic and health-sprite from player, and fix bugs

### DIFF
--- a/rigth2death/characters/Health.py
+++ b/rigth2death/characters/Health.py
@@ -1,0 +1,18 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Health:
+    life: int = 100
+    max_life: int = life
+
+    def receive_damage(self, damage: int) -> None:
+        new_life_points = self.life - abs(damage)
+        self.life = new_life_points if new_life_points >= 0 else 0
+
+    def recover(self, life_points: int):
+        new_life_points = self.life + abs(life_points)
+        self.life = new_life_points if new_life_points <= self.max_life else self.max_life
+
+    def is_dead(self):
+        return self.life <= 0

--- a/rigth2death/characters/enemies/Zombies.py
+++ b/rigth2death/characters/enemies/Zombies.py
@@ -4,6 +4,7 @@ from enum import Enum
 import pygame
 
 import Constants
+from characters.Health import Health
 from utils import Utils
 from utils.CustomSprite import CustomSprite
 
@@ -12,10 +13,10 @@ class Zombie:
 
     def __init__(self):
         self.sprite = CustomSprite(Utils.img('zombies.png'), 5, is_vertical=False)
-        self.sprite_death: CustomSprite = CustomSprite(Utils.img('zombie1_death.png'), 7, is_vertical=False)
+        self.death_sprite: CustomSprite = CustomSprite(Utils.img('zombie1_death.png'), 7, is_vertical=False)
         self.speed = 3
         self.power = 1
-        self.health = 100
+        self.health = Health()
 
         self.select_initial_position()
 
@@ -38,26 +39,25 @@ class Zombie:
             self.sprite.y(self.sprite.y() + (self.speed if diff_y > 0 else - self.speed))
 
     def add_damage(self, damage: int) -> None:
+        self.health.receive_damage(damage)
 
-        self.health -= damage
-
-        if self.health <= 0:
+        if self.health.is_dead():
             print("Me mori zombie")
-            self.sprite_death.rect.x = self.sprite.x()
-            self.sprite_death.rect.y = self.sprite.y()
-            self.sprite_death.init_image_vars()
+            self.death_sprite.rect.x = self.sprite.x()
+            self.death_sprite.rect.y = self.sprite.y()
+            self.death_sprite.init_image_vars()
 
     def is_dead(self):
-        return self.health <= 0
+        return self.health.is_dead()
 
     def play(self):
         if self.is_dead():
-            self.sprite_death.play()
+            self.death_sprite.play()
         else:
             self.sprite.play()
 
     def is_death_animation_complete(self):
-        return self.sprite_death.sequence == self.sprite_death.currentImage + 1
+        return self.death_sprite.sequence == self.death_sprite.currentImage + 1
 
 
 class ZombieType(Enum):

--- a/rigth2death/main.py
+++ b/rigth2death/main.py
@@ -3,7 +3,7 @@ from pygame import Surface
 from pygame.constants import K_LEFT, K_RIGHT, K_UP, K_DOWN, K_SPACE
 
 import Constants
-from enemies.Zombies import EnemyGroup, ZombieFactory
+from characters.enemies.Zombies import EnemyGroup, ZombieFactory
 from rigth2death.characters import Player
 from scenarios.Stages import Stage
 

--- a/rigth2death/scenarios/Elements.py
+++ b/rigth2death/scenarios/Elements.py
@@ -1,0 +1,18 @@
+from utils import Utils
+from utils.CustomSprite import CustomSprite
+
+
+class LifeSprite:
+
+    def __init__(self):
+        self.sprite = CustomSprite(Utils.img_player_stuffs('life.png'), 11, scale=3)
+        self.sprite.images = self.sprite.images[::-1]
+        self.sprite.image = self.sprite.images[0]
+
+    def play(self, times=1):
+        for _ in range(times):
+            self.sprite.play()
+
+    def playback(self, times=1):
+        for _ in range(times):
+            self.sprite.playback()

--- a/rigth2death/utils/CustomSprite.py
+++ b/rigth2death/utils/CustomSprite.py
@@ -61,6 +61,13 @@ class CustomSprite(pygame.sprite.Sprite):
 
         self.update_image_vars()
 
+    def playback(self):
+        self.currentImage -= 1
+        if self.currentImage < 0:
+            self.currentImage = self.sequence - 1
+
+        self.update_image_vars()
+
     def update_image_vars(self):
         self.image = self.images[self.currentImage]
 


### PR DESCRIPTION
- Extract health logic and health animation from Player.py, adding observer pattern.

Fix:
- Bug https://github.com/fcoreyesc/rigth2death_python/issues/11

Enhancements :

- https://github.com/fcoreyesc/rigth2death_python/issues/10
- https://github.com/fcoreyesc/rigth2death_python/issues/6